### PR TITLE
[PLUGIN-1743] Enable DECOMPRESS_UNTIL_EOF

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>1.10</version>
+    </dependency>
+    <dependency>
       <groupId>io.cdap.cdap</groupId>
       <artifactId>cdap-etl-api</artifactId>
       <version>${cdap.version}</version>

--- a/src/main/java/io/cdap/plugin/decompress/action/DecompressAction.java
+++ b/src/main/java/io/cdap/plugin/decompress/action/DecompressAction.java
@@ -54,6 +54,7 @@ import java.util.regex.Pattern;
 public class DecompressAction extends Action {
   private static final Logger LOG = LoggerFactory.getLogger(DecompressAction.class);
   private static final int BUFFER_SIZE = 8024; // Matches default buffer size in IOUtils
+  private static final boolean DECOMPRESS_UNTIL_EOF = true;
 
   private DecompressActionConfig config;
 
@@ -184,7 +185,7 @@ public class DecompressAction extends Action {
     Path actualDestPath = (fileSystem.isDirectory(dest))
       ? new Path(dest.toString() + "/" + source.getName().substring(0, source.getName().lastIndexOf(".")))
       : dest;
-    try (CompressorInputStream input = new CompressorStreamFactory()
+    try (CompressorInputStream input = new CompressorStreamFactory(DECOMPRESS_UNTIL_EOF)
       .createCompressorInputStream(new BufferedInputStream(fileSystem.open(source)));
          BufferedOutputStream out = new BufferedOutputStream(fileSystem.create(actualDestPath), BUFFER_SIZE)) {
       IOUtils.copy(input, out);


### PR DESCRIPTION
## Enable DECOMPRESS_UNTIL_EOF

Jira : [PLUGIN-1743](https://cdap.atlassian.net/browse/PLUGIN-1743)

### Description

Some compressed files may be concatenated, if _ is disabled only the first compressed chunck will be decompressed, hence we enable the DECOMPRESS_UNTIL_EOF option. 

> For this we need minimum apache.commons:commons-compress version 1.10

### Code change

- Modified `DecompressAction.java`
